### PR TITLE
Fix Assassin.tpa backstab bug, level 44

### DIFF
--- a/ArtisansKitpack/lib/Assassin.tpa
+++ b/ArtisansKitpack/lib/Assassin.tpa
@@ -233,7 +233,7 @@ COPY_EXISTING ~backstab.2da~ ~override~
 		SET_2DA_ENTRY (%patch_row%) 42 cols 7
 		SET_2DA_ENTRY (%patch_row%) 43 cols 7
 		SET_2DA_ENTRY (%patch_row%) 44 cols 7
-		SET_2DA_ENTRY (%patch_row%) 45 cols f
+		SET_2DA_ENTRY (%patch_row%) 45 cols 7
 		SET_2DA_ENTRY (%patch_row%) 46 cols 7
 		SET_2DA_ENTRY (%patch_row%) 47 cols 7
 		SET_2DA_ENTRY (%patch_row%) 48 cols 7


### PR DESCRIPTION
At level 44, BACKSTAB.2DA for assassin is written "f", it should be 7.

(This messed up my mod, sg_multikits, because it expects integers here.)