### PR TITLE
Update MonkRevision.tpa for C0MNRO09 reference

### DIFF
--- a/ArtisansKitpack/lib/MonkRevision.tpa
+++ b/ArtisansKitpack/lib/MonkRevision.tpa
@@ -775,7 +775,7 @@ Equipped abilities:
 
 Weight: 4~
 
-COPY_EXISTING ~C0MNRO08.ITM~ OVERRIDE
+COPY_EXISTING ~C0MNRO09.ITM~ OVERRIDE
 SAY NAME1 ~Monk Robes~
 SAY NAME2 ~Robes of the Inner Eye~
 SAY UNIDENTIFIED_DESC ~Robes worn by monks of various monastic orders.


### PR DESCRIPTION
Changed duplicate reference to monk robe C0MNRO08 to C0MNRO09 in COPY_EXISTING step on line 778