### PR TITLE
Removing reference to 2DAs folder that does not exist for samurai kit

### DIFF
--- a/ArtisansKitpack/lib/Samurai.tpa
+++ b/ArtisansKitpack/lib/Samurai.tpa
@@ -1,4 +1,3 @@
-COPY ~%MOD_FOLDER%/Fighter/Samurai/2DAs~ ~OVERRIDE~
 COPY ~%MOD_FOLDER%/Fighter/Samurai/BAMS~ ~OVERRIDE~
 COPY ~%MOD_FOLDER%/Fighter/Samurai/spells~ ~OVERRIDE~
 COPY ~%MOD_FOLDER%/bmp~ ~OVERRIDE~


### PR DESCRIPTION
Sorry for the last PR something went wonky I tried to fix but just decided to re-pull and start over since it was easy.

This just fixes an issue with the installer failing on the Samurai Kit for fighter due to 2DAs folder missing.

Tested successfully after removal locally.